### PR TITLE
Fixed errors and warnings (clang 3.4)

### DIFF
--- a/dessert.hpp
+++ b/dessert.hpp
@@ -48,17 +48,17 @@
 #include <sstream>
 namespace dessert {
     using namespace std;
+	using timer = chrono::high_resolution_clock;
+	template<typename T> string to_str( const T &t ) { stringstream ss; return (ss << t) ? ss.str() : "??"; }
+	template<          > string to_str( const timer::time_point &start ) {
+	    return to_str( double((timer::now() - start).count()) * timer::period::num / timer::period::den );
+	}
     class suite {
-        using timer = chrono::high_resolution_clock;
         timer::time_point start = timer::now();
         deque< string > xpr;
         int ok = false, has_bp = false;
         enum { BREAKPOINT, BREAKPOINTS, PASSED, FAILED, TESTNO };
         static unsigned &get(int i) { static unsigned var[TESTNO+1] = {}; return var[i]; }
-        template<typename T> static string to_str( const T &t ) { stringstream ss; return ss << t ? ss.str() : "??"; }
-        template<          > static string to_str( const timer::time_point &start ) {
-            return to_str( double((timer::now() - start).count()) * timer::period::num / timer::period::den );
-        }
     public:
         static bool queue( const function<void()> &fn, const string &text ) {
             static auto start = timer::now();
@@ -99,9 +99,9 @@ namespace dessert {
                 xpr[1].resize( (xpr[1] != xpr[2]) * xpr[1].size() );
                 xpr.push_back( "(unexpected)" );
             }
-            for( unsigned it = 0; it < xpr.size(); ++it ) {
-                fprintf( stderr, xpr[it].size() ? "%s%s\n" : "", tab[ !it ].c_str(), xpr[it].c_str() );
-            }
+            for( unsigned it = 0; it < xpr.size(); ++it )
+				if(xpr[it].size())
+                	fprintf( stderr, "%s%s\n", tab[ !it ].c_str(), xpr[it].c_str() );
         }
 #       define dessert$join(str, num) str##num
 #       define dessert$glue(str, num) dessert$join(str, num)


### PR DESCRIPTION
./dessert.hpp:59:44: error: explicit specialization of 'to_str' in class scope
template<          > static string to_strtimer::time_point(
const timer::time_point &start ) {
^

./dessert.hpp:58:89: error: invalid operands to binary expression ('stringstream' (aka 'basic_stringstream<char>') and 'const
std::__1::chrono::time_point<std::__1::chrono::steady_clock,
std::__1::chrono::duration<long long, std::__1::ratio<1, 1000000000> > >')
template<typename T> static string to_str( const T &t ) { stringstream ss; return (ss << t) ? ss.str() : "??"; }
