### PR TITLE
Fixing clang 'non-local lambda .. capture-default'

### DIFF
--- a/dessert.hpp
+++ b/dessert.hpp
@@ -8,7 +8,7 @@
         ( dessert::suite(#__VA_ARGS__,__FILE__,__LINE__,0) < __VA_ARGS__ ) )
 #define desserts(...) \
         static void dessert$line(dessert)(); \
-        static const bool dessert$line(dsstSuite_) = dessert::suite::queue( [&](){ \
+        static const bool dessert$line(dsstSuite_) = dessert::suite::queue( [](){ \
             std::string title = "" __VA_ARGS__; if( title.empty() ) title = "Suite"; \
             fprintf( stderr, "------  %s\n", title.c_str() ); \
             dessert$line(dessert)(); \


### PR DESCRIPTION
Macos latest clang, gave me a capture-default error, as below. Removing capture spec seems harmless here  ? 

g++-4.9 -std=c++11 sample.cc  < OK
clang++ -std=c++11 sample.cc 
sample.cc:4:1: error: non-local lambda expression cannot have a capture-default
desserts() {
^
./dessert.hpp:11:78: note: expanded from macro 'desserts'
        static const bool dessert$line(dsstSuite_) = dessert::suite::queue( [&](){ \
                                                                             ^
sample.cc:26:1: error: non-local lambda expression cannot have a capture-default

...
clang++ --version
Apple LLVM version 7.0.2 (clang-700.1.81
